### PR TITLE
feat: make email and website optional in item creation flow

### DIFF
--- a/lib/core/extensions/string_validators.dart
+++ b/lib/core/extensions/string_validators.dart
@@ -28,6 +28,12 @@ extension StringValidators on String? {
     return null;
   }
 
+  String? get emailOptionalError {
+    if (isNullOrBlank) return null;
+    if (!isValidEmail) return CoreStrings.emailInvalid;
+    return null;
+  }
+
   String? get passwordError {
     final value = this?.trim();
     if (value == null) return CoreStrings.passwordRequired;

--- a/lib/data/datasources/local/database/database_helper.dart
+++ b/lib/data/datasources/local/database/database_helper.dart
@@ -56,7 +56,7 @@ class DataBaseHelper {
         $colGroup TEXT NOT NULL,
         $colService TEXT NOT NULL,
         $colSite TEXT,
-        $colEmail TEXT NOT NULL,
+        $colEmail TEXT,
         $colLogin TEXT NOT NULL,
         $colPassword TEXT NOT NULL,
         $colIsDeleted INTEGER NOT NULL DEFAULT 0,

--- a/lib/data/models/itens_model.dart
+++ b/lib/data/models/itens_model.dart
@@ -7,7 +7,7 @@ class ItensModel extends ItensEntity {
     required super.group,
     required super.service,
     super.site,
-    required super.email,
+    super.email,
     required super.login,
     required super.password,
     super.isDeleted = false,

--- a/lib/domain/entities/itens_entity.dart
+++ b/lib/domain/entities/itens_entity.dart
@@ -1,18 +1,17 @@
 import 'package:equatable/equatable.dart';
 import 'package:lockpass/core/extensions/string_validators.dart';
 
-class ItensEntity extends Equatable{
+class ItensEntity extends Equatable {
   final String userId;
   final int? id;
   final String group;
   final String service;
   final String? site;
-  final String email;
+  final String? email;
   final String login;
   final String password;
   final bool isDeleted;
   final DateTime? deletedAt;
-
 
   const ItensEntity({
     required this.userId,
@@ -20,29 +19,27 @@ class ItensEntity extends Equatable{
     required this.group,
     required this.service,
     this.site,
-    required this.email,
+    this.email,
     required this.login,
     required this.password,
     this.isDeleted = false,
     this.deletedAt,
   });
 
-  const ItensEntity.empty()
-      : userId = '',
-        id = 0,
-        group = '',
-        service = '',
-        site = '',
-        email = '',
-        login = '',
-        password = '',
-        isDeleted = false,
-        deletedAt = null;
+  // const ItensEntity.empty()
+  //     : userId = '',
+  //       id = 0,
+  //       group = '',
+  //       service = '',
+  //       site = null,
+  //       email = null,
+  //       login = '',
+  //       password = '',
+  //       isDeleted = false,
+  //       deletedAt = null;
 
-    bool isValid() {
-    return service.isNotNullOrBlank &&
-        login.isNotNullOrBlank &&
-        password.isNotNullOrBlank;
+  bool isValid() {
+    return service.isNotNullOrBlank && login.isNotNullOrBlank && password.isNotNullOrBlank;
   }
 
   bool isDifferentFrom(ItensEntity other) {
@@ -53,7 +50,7 @@ class ItensEntity extends Equatable{
         login != other.login ||
         password != other.password ||
         isDeleted != other.isDeleted;
-  }  
+  }
 
   ItensEntity copyWith({
     String? userId,
@@ -83,15 +80,15 @@ class ItensEntity extends Equatable{
 
   @override
   List<Object?> get props => [
-    userId,
-    id,
-    group,
-    service,
-    site,
-    email,
-    login,
-    password,
-    isDeleted,
-    deletedAt,
-  ];
+        userId,
+        id,
+        group,
+        service,
+        site,
+        email,
+        login,
+        password,
+        isDeleted,
+        deletedAt,
+      ];
 }

--- a/lib/features/add_item/domain/usecases/create_item_usecase.dart
+++ b/lib/features/add_item/domain/usecases/create_item_usecase.dart
@@ -37,15 +37,23 @@ class CreateItemUseCase {
     final encryptUid = EncryptDecrypt.generateUserMask(uid);
     final encryptedGroup = await EncryptDecrypt.encryptInformation(plainText: group.trim(), dek: dek);
     final encryptedService = await EncryptDecrypt.encryptInformation(plainText: item.service.trim(), dek: dek);
-    final encryptedSite =
-        item.site != null ? await EncryptDecrypt.encryptInformation(plainText: item.site!.trim(), dek: dek) : null;
-    final encryptedEmail = await EncryptDecrypt.encryptInformation(plainText: item.email.trim(), dek: dek);
+    final encryptedSite = item.site != null && item.site!.trim().isNotEmpty
+        ? await EncryptDecrypt.encryptInformation(
+            plainText: item.site!.trim(),
+            dek: dek,
+          )
+        : null;
+    final encryptedEmail = item.email != null && item.email!.trim().isNotEmpty
+        ? await EncryptDecrypt.encryptInformation(
+            plainText: item.email!.trim(),
+            dek: dek,
+          )
+        : null;
     final encryptedLogin = await EncryptDecrypt.encryptInformation(plainText: item.login.trim(), dek: dek);
     final encryptedPassword = await EncryptDecrypt.encryptInformation(plainText: item.password.trim(), dek: dek);
 
     final isSecurity = encryptedGroup.isNotNull &&
         encryptedService.isNotNull &&
-        encryptedEmail.isNotNull &&
         encryptedLogin.isNotNull &&
         encryptedPassword.isNotNull;
     if (!isSecurity) {

--- a/lib/features/add_item/presentation/controller/add_item_controller.dart
+++ b/lib/features/add_item/presentation/controller/add_item_controller.dart
@@ -23,14 +23,11 @@ class AddItemController extends Cubit<AddItemState> {
   void onFormChanged({
     required String group,
     required String service,
-    required String email,
     required String login,
     required String password,
   }) {
     final valid = group.isNotNullOrBlank &&
         service.isNotNullOrBlank &&
-        email.isNotNullOrBlank &&
-        email.isValidEmail &&
         login.isNotNullOrBlank &&
         password.isNotNullOrBlank;
 

--- a/lib/features/add_item/presentation/page/add_item_page.dart
+++ b/lib/features/add_item/presentation/page/add_item_page.dart
@@ -90,7 +90,6 @@ class _AddItemPageState extends State<AddItemPage> {
                         addItemController.onFormChanged(
                           group: groupController.text,
                           service: serviceController.text,
-                          email: emailController.text,
                           login: loginController.text,
                           password: passwordController.text,
                         );
@@ -199,7 +198,7 @@ class _AddItemPageState extends State<AddItemPage> {
                               label: CoreStrings.labelEmailRegister,
                               controller: emailController,
                               color: CoreColors.textPrimary,
-                              validator: (value) => value.emailError,
+                              validator: (value) => value.emailOptionalError,
                             ),
                           ),
                           ListTile(
@@ -262,7 +261,8 @@ class _AddItemPageState extends State<AddItemPage> {
                                           service: serviceController.text.trim(),
                                           site: siteController.text.trim().isEmpty
                                             ? null : siteController.text.trim(),
-                                          email: emailController.text.trim(),
+                                          email: emailController.text.trim().isEmpty
+                                            ? null : emailController.text.trim(),
                                           login: loginController.text.trim(),
                                           password: passwordController.text.trim(),
                                         );

--- a/lib/features/list_item/domain/usecases/edit_item_usecase.dart
+++ b/lib/features/list_item/domain/usecases/edit_item_usecase.dart
@@ -29,15 +29,16 @@ class EditItemUseCase {
     final encryptUid = EncryptDecrypt.generateUserMask(uid);
     final encryptedGroup = await EncryptDecrypt.encryptInformation(plainText: item.group.trim(), dek: dek);
     final encryptedService = await EncryptDecrypt.encryptInformation(plainText: item.service.trim(), dek: dek);
-    final encryptedSite =
-        item.site != null ? await EncryptDecrypt.encryptInformation(plainText: item.site!.trim(), dek: dek) : null;
-    final encryptedEmail = await EncryptDecrypt.encryptInformation(plainText: item.email.trim(), dek: dek);
+    final encryptedSite = item.site != null && item.site!.trim().isNotEmpty 
+        ? await EncryptDecrypt.encryptInformation(plainText: item.site!.trim(), dek: dek) : null;
+    final encryptedEmail = item.email != null && item.email!.trim().isNotEmpty
+        ? await EncryptDecrypt.encryptInformation(plainText: item.email!.trim(), dek: dek)
+        : null;
     final encryptedLogin = await EncryptDecrypt.encryptInformation(plainText: item.login.trim(), dek: dek);
     final encryptedPassword = await EncryptDecrypt.encryptInformation(plainText: item.password.trim(), dek: dek);
 
     final isSecurity = encryptedGroup.isNotNull &&
         encryptedService.isNotNull &&
-        encryptedEmail.isNotNull &&
         encryptedLogin.isNotNull &&
         encryptedPassword.isNotNull;
     if (!isSecurity) {

--- a/lib/features/list_item/domain/usecases/load_items_usecase.dart
+++ b/lib/features/list_item/domain/usecases/load_items_usecase.dart
@@ -49,10 +49,14 @@ class LoadItemsUseCase {
           userId: uid,
           group: await EncryptDecrypt.decryptInformation(payloadB64: item.group, dek: dek) ?? "Erro",
           service: await EncryptDecrypt.decryptInformation(payloadB64: item.service, dek: dek) ?? "Serviço Indisponível",
-          email: await EncryptDecrypt.decryptInformation(payloadB64: item.email, dek: dek) ?? "",
+          email: item.email != null
+            ? await EncryptDecrypt.decryptInformation(payloadB64: item.email!, dek: dek) ?? ""
+            : "",
           login: await EncryptDecrypt.decryptInformation(payloadB64: item.login, dek: dek) ?? "",
           password: await EncryptDecrypt.decryptInformation(payloadB64: item.password, dek: dek) ?? "",
-          site: item.site != null ? await EncryptDecrypt.decryptInformation(payloadB64: item.site!, dek: dek) : "",
+          site: item.site != null
+            ? await EncryptDecrypt.decryptInformation(payloadB64: item.site!, dek: dek) ?? ""
+            : "",
         );
       }),
     );

--- a/lib/features/list_item/presentation/controller/list_item_controller.dart
+++ b/lib/features/list_item/presentation/controller/list_item_controller.dart
@@ -221,7 +221,7 @@ class ListItemController extends Cubit<ListItemState> {
     final filtered = state.allItems.where((e) {
       return e.service.toLowerCase().contains(query) ||
           e.login.toLowerCase().contains(query) ||
-          e.email.toLowerCase().contains(query) ||
+          (e.email ?? '').toLowerCase().contains(query) ||
           (e.site ?? '').toLowerCase().contains(query) ||
           e.group.toLowerCase().contains(query);
     }).toList();

--- a/lib/features/list_item/presentation/widgets/bottom_sheet/item_details_bottom_sheet.dart
+++ b/lib/features/list_item/presentation/widgets/bottom_sheet/item_details_bottom_sheet.dart
@@ -80,7 +80,7 @@ class _ItemDetailsBottomSheetState extends State<ItemDetailsBottomSheet> {
     groupController.text = item.group;
     serviceController.text = item.service;
     siteController.text = item.site ?? '';
-    emailController.text = item.email;
+    emailController.text = item.email?? '';
     loginController.text = item.login;
     passwordController.text = item.password;
   }

--- a/lib/features/list_item/presentation/widgets/item_info_view_widget.dart
+++ b/lib/features/list_item/presentation/widgets/item_info_view_widget.dart
@@ -47,7 +47,7 @@ class ItemInfoViewWidget extends StatelessWidget {
         ),
         InfoItemCustom(
           title: CoreStrings.email,
-          subtitle: item.email.isNotNullOrBlank? item.email : CoreStrings.notInformed,
+          subtitle: item.email.isNotNullOrBlank? item.email! : CoreStrings.notInformed,
           titleColor: CoreColors.textSecundary,
           subtitleColor: CoreColors.textSecundary,
         ),


### PR DESCRIPTION
- removed email requirement from form validation
- added support for nullable email and site across layers
- updated usecases to handle optional encryption
- adjusted UI validation to allow empty optional fields
- ensured consistency between form, domain and persistence